### PR TITLE
[thorvg] updated to v1.0.4

### DIFF
--- a/copy_libthorvg.sh
+++ b/copy_libthorvg.sh
@@ -9,7 +9,7 @@ abi="${1:-all}"
 
 copy_one() {
     abi_dir="$1"
-    lib_source="$THORVG_DIR/build-${abi_dir}/src/libthorvg.a"
+    lib_source="$THORVG_DIR/build-${abi_dir}/src/libthorvg-1.a"
 
     if [ ! -d "$THORVG_DIR/lib" ]; then
         echo "lib directory doesn't exist in thorvg directory. Creating lib directory..."
@@ -24,13 +24,13 @@ copy_one() {
     fi
 
     if [ ! -f "$lib_source" ]; then
-        echo "libthorvg.a not found: $lib_source"
+        echo "libthorvg-1.a not found: $lib_source"
         echo "Run ./build_libthorvg.sh ${abi_dir} first."
         exit 1
     fi
 
     cp "$lib_source" "$THORVG_DIR/lib/$abi_dir/"
-    echo "libthorvg.a copied to thorvg/lib/$abi_dir/"
+    echo "libthorvg-1.a copied to thorvg/lib/$abi_dir/"
 }
 
 case "$abi" in

--- a/thorvg-core/build.gradle
+++ b/thorvg-core/build.gradle
@@ -211,7 +211,7 @@ tasks.register('buildThorvg') {
 
             def buildDir = new File(nativeRootDir, "build-gradle-${target.abiDir}")
             def outputDir = new File(libDir, target.abiDir)
-            def staticLib = new File(buildDir, 'src/libthorvg.a')
+            def staticLib = new File(buildDir, 'src/libthorvg-1.a')
 
             println "Building ThorVG for ${target.abiDir}"
             delete(buildDir)
@@ -252,7 +252,7 @@ tasks.register('buildThorvg') {
                 from staticLib
                 into outputDir
             }
-            println "Copied libthorvg.a to ${outputDir.absolutePath}"
+            println "Copied libthorvg-1.a to ${outputDir.absolutePath}"
         }
     }
 }

--- a/thorvg-core/src/main/cpp/CMakeLists.txt
+++ b/thorvg-core/src/main/cpp/CMakeLists.txt
@@ -7,7 +7,7 @@ set(THORVG_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../thorvg)
 if (${ANDROID_ABI} STREQUAL "arm64-v8a" OR ${ANDROID_ABI} STREQUAL "x86_64")
     add_library(lib_thorvg STATIC IMPORTED)
     set_target_properties(lib_thorvg PROPERTIES IMPORTED_LOCATION
-            ${THORVG_DIR}/lib/${ANDROID_ABI}/libthorvg.a)
+            ${THORVG_DIR}/lib/${ANDROID_ABI}/libthorvg-1.a)
 
     # build application's shared lib
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14")

--- a/thorvg-core/src/main/cpp/LottieData.cpp
+++ b/thorvg-core/src/main/cpp/LottieData.cpp
@@ -20,7 +20,6 @@
  * SOFTWARE.
  */
 
-#include <thread>
 #include <android/log.h>
 #include "LottieData.h"
 
@@ -33,22 +32,26 @@ LottieDrawable::Data::Data(const char *content, uint32_t length) {
     mAnimation = tvg::Animation::gen();
     // Acquire a picture which associated with the animation.
     auto picture = mAnimation->picture();
-    if (picture->load(mContent, mContentLength, "lottie", true) != tvg::Result::Success) {
+    if (picture->load(mContent, mContentLength, "lottie", nullptr, true) != tvg::Result::Success) {
         LOGE("Error: Lottie is not supported. Did you enable Lottie Loader?");
         return;
     }
 
     // Create a canvas
-    mCanvas = tvg::SwCanvas::gen();
-    mCanvas->push(tvg::cast<tvg::Picture>(picture));
+    mCanvas = tvg::SwCanvas::gen(tvg::EngineOption::Default);
+    mCanvas->add(picture);
+}
+
+LottieDrawable::Data::~Data() {
+    delete(mCanvas);
+    delete(mAnimation);
 }
 
 void LottieDrawable::Data::setBufferSize(uint32_t *buffer, float width, float height) {
     LOGI("LottieDrawable::Data::setBufferSize width=%f, height=%f", width, height);
     mCanvas->sync();
-    mCanvas->clear(false);
     mCanvas->target(buffer, (uint32_t) width, (uint32_t) width, (uint32_t) height,
-            tvg::SwCanvas::ABGR8888);
+            tvg::ColorSpace::ABGR8888);
     mAnimation->picture()->size(width, height);
 }
 
@@ -56,7 +59,7 @@ void LottieDrawable::Data::draw(uint32_t frame) {
     if (!mCanvas) return;
 //    LOGI("LottieDrawable::Data::draw mAnimation=%d", mAnimation->curFrame());
     mAnimation->frame(frame);
-    mCanvas->update(mAnimation->picture());
-    mCanvas->draw();
+    mCanvas->update();
+    mCanvas->draw(true);
     mCanvas->sync();
 }

--- a/thorvg-core/src/main/cpp/LottieData.h
+++ b/thorvg-core/src/main/cpp/LottieData.h
@@ -37,11 +37,12 @@ namespace LottieDrawable {
     class Data {
     public:
         Data(const char* content, uint32_t strLength);
+        ~Data();
         void setBufferSize(uint32_t* buffer, float width, float height);
         void draw(uint32_t frame);
-        std::unique_ptr<tvg::Animation> mAnimation;
+        tvg::Animation* mAnimation = nullptr;
     private:
-        std::unique_ptr<tvg::SwCanvas> mCanvas;
+        tvg::SwCanvas* mCanvas = nullptr;
         const char* mContent;
         uint32_t mContentLength;
     };

--- a/thorvg-core/src/main/cpp/SvgData.cpp
+++ b/thorvg-core/src/main/cpp/SvgData.cpp
@@ -26,16 +26,21 @@ SvgComposition::Data::Data(const char *content, uint32_t length) {
     SVG_LOGI("SvgComposition::Data::Data length=%d", length);
 
     auto picture = tvg::Picture::gen();
-    if (picture->load(content, length, "svg", true) != tvg::Result::Success) {
+    if (picture->load(content, length, "svg", nullptr, true) != tvg::Result::Success) {
         SVG_LOGE("Error: SVG is not supported. Did you enable SVG Loader?");
+        tvg::Paint::rel(picture);
         return;
     }
 
     picture->size(&mWidth, &mHeight);
 
-    mCanvas = tvg::SwCanvas::gen();
-    mPicture = picture.get();
-    mCanvas->push(std::move(picture));
+    mCanvas = tvg::SwCanvas::gen(tvg::EngineOption::Default);
+    mPicture = picture;
+    mCanvas->add(mPicture);
+}
+
+SvgComposition::Data::~Data() {
+    delete(mCanvas);
 }
 
 void SvgComposition::Data::setBufferSize(uint32_t *buffer, float width, float height) {
@@ -43,9 +48,8 @@ void SvgComposition::Data::setBufferSize(uint32_t *buffer, float width, float he
 
     SVG_LOGI("SvgComposition::Data::setBufferSize width=%f, height=%f", width, height);
     mCanvas->sync();
-    mCanvas->clear(false);
     mCanvas->target(buffer, (uint32_t) width, (uint32_t) width, (uint32_t) height,
-                    tvg::SwCanvas::ABGR8888);
+                    tvg::ColorSpace::ABGR8888);
     mPicture->size(width, height);
 }
 
@@ -53,6 +57,6 @@ void SvgComposition::Data::draw() {
     if (!mCanvas || !mPicture) return;
 
     mCanvas->update();
-    mCanvas->draw();
+    mCanvas->draw(true);
     mCanvas->sync();
 }

--- a/thorvg-core/src/main/cpp/SvgData.h
+++ b/thorvg-core/src/main/cpp/SvgData.h
@@ -37,13 +37,14 @@ namespace SvgComposition {
     class Data {
     public:
         Data(const char* content, uint32_t strLength);
+        ~Data();
         void setBufferSize(uint32_t* buffer, float width, float height);
         void draw();
         tvg::Picture* mPicture = nullptr;
         float mWidth = 0.0f;
         float mHeight = 0.0f;
     private:
-        std::unique_ptr<tvg::SwCanvas> mCanvas;
+        tvg::SwCanvas* mCanvas = nullptr;
     };
 
 } // namespace SvgComposition

--- a/thorvg-core/src/main/cpp/lottie-libs.cpp
+++ b/thorvg-core/src/main/cpp/lottie-libs.cpp
@@ -34,7 +34,7 @@ Java_org_thorvg_core_lottie_LottieNativeBindings_nCreateLottie(JNIEnv *env, jcla
         return 0;
     }
 
-    if (tvg::Initializer::init(tvg::CanvasEngine::Sw, 3) != tvg::Result::Success) {
+    if (tvg::Initializer::init(3) != tvg::Result::Success) {
         return 0;
     }
 
@@ -54,7 +54,7 @@ Java_org_thorvg_core_lottie_LottieNativeBindings_nCreateLottie(JNIEnv *env, jcla
 
 extern "C" void
 Java_org_thorvg_core_lottie_LottieNativeBindings_nDestroyLottie(JNIEnv* env, jclass clazz, jlong lottie_ptr) {
-    tvg::Initializer::term(tvg::CanvasEngine::Sw);
+    tvg::Initializer::term();
 
     if (lottie_ptr == 0) {
         return;

--- a/thorvg-core/src/main/cpp/svg-libs.cpp
+++ b/thorvg-core/src/main/cpp/svg-libs.cpp
@@ -32,7 +32,7 @@ Java_org_thorvg_core_svg_SvgNativeBindings_nCreateSvg(JNIEnv *env, jclass clazz,
         return 0;
     }
 
-    if (tvg::Initializer::init(tvg::CanvasEngine::Sw, 3) != tvg::Result::Success) {
+    if (tvg::Initializer::init(3) != tvg::Result::Success) {
         return 0;
     }
 
@@ -52,7 +52,7 @@ Java_org_thorvg_core_svg_SvgNativeBindings_nCreateSvg(JNIEnv *env, jclass clazz,
 
 extern "C" void
 Java_org_thorvg_core_svg_SvgNativeBindings_nDestroySvg(JNIEnv* env, jclass clazz, jlong svg_ptr) {
-    tvg::Initializer::term(tvg::CanvasEngine::Sw);
+    tvg::Initializer::term();
 
     if (svg_ptr == 0) {
         return;


### PR DESCRIPTION
Update ThorVG submodule from `v0.15.0` to `v1.0.4`.

issue: #15 

## Migration Notes

- ThorVG static library output changed from `libthorvg.a` to `libthorvg-1.a`.
- Updated Android build scripts and CMake link path to use the new library name.
- Migrated ThorVG 1.x API changes:
  - `push()` -> `add()`
  - `draw()` -> `draw(true)`
  - `SwCanvas::ABGR8888` -> `ColorSpace::ABGR8888`
  - `Initializer::init/term(CanvasEngine::Sw, ...)` -> `Initializer::init/term(...)`
- Adjusted lifetime handling for ThorVG objects now returned as raw pointers instead of `unique_ptr`.
