### PR TITLE
fix: Lottie frame and Replay issues

### DIFF
--- a/thorvg-compose/src/main/java/org/thorvg/compose/lottie/Lottie.kt
+++ b/thorvg-compose/src/main/java/org/thorvg/compose/lottie/Lottie.kt
@@ -236,9 +236,9 @@ fun Lottie(
         }
 
         val resolvedFirstFrame = firstFrame.coerceAtLeast(0)
-        renderState.lastFrame = (lastFrame ?: composition.frameCount)
+        renderState.lastFrame = (lastFrame ?: composition.lastFrame)
             .coerceAtLeast(resolvedFirstFrame)
-            .coerceAtMost(composition.frameCount)
+            .coerceAtMost(composition.lastFrame)
         renderState.firstFrame = resolvedFirstFrame.coerceAtMost(renderState.lastFrame)
         renderState.setCompositionSize(canvasSize.width, canvasSize.height)
 

--- a/thorvg-core/src/main/java/org/thorvg/core/lottie/LottieComposition.kt
+++ b/thorvg-core/src/main/java/org/thorvg/core/lottie/LottieComposition.kt
@@ -49,6 +49,12 @@ class LottieComposition private constructor(
         get() = nativeLottie.frameCount
 
     /**
+     * Last valid frame index that can be rendered.
+     */
+    val lastFrame: Int
+        get() = (frameCount - 1).coerceAtLeast(0)
+
+    /**
      * Total animation duration in milliseconds.
      */
     val duration: Long
@@ -147,7 +153,7 @@ class LottieRenderState {
     var lastFrame = 0
         set(value) {
             composition?.let {
-                field = value.coerceAtMost(it.frameCount)
+                field = value.coerceAtLeast(0).coerceAtMost(it.lastFrame)
                 updateFrameInterval()
             }
         }
@@ -179,7 +185,7 @@ class LottieRenderState {
 
     protected fun updateFrameInterval() {
         val currentComposition = composition ?: return
-        val totalFrames = lastFrame - firstFrame
+        val totalFrames = lastFrame - firstFrame + 1
         frameInterval = when {
             totalFrames <= 0 -> 0L
             speed <= 0f -> 0L

--- a/thorvg-view/src/main/java/org/thorvg/view/lottie/LottieDrawable.kt
+++ b/thorvg-view/src/main/java/org/thorvg/view/lottie/LottieDrawable.kt
@@ -242,6 +242,7 @@ class LottieDrawable internal constructor() : ThorVGDrawable(), Animatable {
      * Starts playback from [firstFrame].
      */
     override fun start() {
+        handler.removeCallbacks(nextFrameRunnable)
         isRunning = true
         isEnded = false
         isStarted = false

--- a/thorvg-view/src/main/java/org/thorvg/view/lottie/LottieDrawable.kt
+++ b/thorvg-view/src/main/java/org/thorvg/view/lottie/LottieDrawable.kt
@@ -443,7 +443,7 @@ class LottieDrawable internal constructor() : ThorVGDrawable(), Animatable {
             val drawable = LottieDrawable()
             drawable.lottieState.composition = LottieComposition.fromRawResource(resources, resId)
             drawable.lottieState.composition?.let { composition ->
-                drawable.setLastFrame(composition.frameCount)
+                drawable.setLastFrame(composition.lastFrame)
             }
             return drawable
         }


### PR DESCRIPTION
## 1. [fix: lottie frame bounds](https://github.com/thorvg/thorvg.android/pull/30/changes/955756578863a0a710497287b6838eaedd158b06)

Use the last valid frame index instead of frameCount as the playback end frame, preventing an extra frame from being rendered in View and Compose.


<table>
  <tr>
    <th>before(3 second, 3 frame)</th>
    <th>after(2 second, 2 frame)</th>
    <th>Web lottie view(2 second, 2 frame)</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/e1f524d7-b41c-41eb-ab8a-0f99826c532d"></video></td>
    <td><video src="https://github.com/user-attachments/assets/1db19a8c-8b85-4bea-87c7-a93822b16be9"></video></td>
    <td><video src="https://github.com/user-attachments/assets/b8baae8d-a2ac-4511-801c-cd302024e3c3"></video></td>
  </tr>
</table>


## 2. [fix: prevent duplicate nextFrameRunnable](https://github.com/thorvg/thorvg.android/pull/30/changes/28ee92ee7c7509c669916fcb35e333df164c0385)

This causes an issue when Replay is triggered.


https://github.com/user-attachments/assets/dad5a54e-05fa-4a2c-9540-fd75e4fa0410




<details><summary>fixed</summary>


## 3. [fix: Lottie duration unit conversion](https://github.com/thorvg/thorvg.android/pull/30/changes/e21d6e77db3b2ff7ce69ef4d5d4f6cc53f5a123b)


```cpp
    /**
     * @brief Retrieves the duration of the animation in seconds.
     *
     * @return The duration of the animation in seconds.
     *
     * @note If the Picture is not properly configured, this function will return 0.
     */
    float duration() const noexcept;
```

ThorVG returns duration in seconds as a float,
for example 2.5 means 2.5s.

Convert it to integer milliseconds before crossing
the JNI boundary so sub-second precision survives.

This avoids truncating 2.5s to 2 on the native side.


## 4. [fix: terminate ThorVG after destroying Lottie data](https://github.com/thorvg/thorvg.android/pull/30/changes/2e0359818f7f3bddb86d8a08c7ea165f83662e3a)

Destroy LottieDrawable::Data first so its owned
ThorVG resources, including the canvas and animation
are released before tvg::Initializer::term() runs.

`LottieDrawable` has `SwCanvas` and `Animation`.


## 5. [fix: use UTF-8 byte length for Lottie loading](https://github.com/thorvg/thorvg.android/pull/30/changes/0d6ac18d67b0eb6b69272a6b49570af376d6ad69)

| Kotlin String | JNI GetStringUTFLength | JNI GetStringUTFchars|
|-|-|-|
|<img width="739" height="281" alt="image" src="https://github.com/user-attachments/assets/952d2258-4da1-4d33-b2d2-f6c18129c507" />|<img width="679" height="167" alt="image" src="https://github.com/user-attachments/assets/bfe32727-0b57-44e8-8d2e-973cc7ccb9f8" />|<img width="1300" height="242" alt="image" src="https://github.com/user-attachments/assets/bfe1bda2-ce60-4654-bc85-8c57df3c9f5c" />|


Use `GetStringUTFLength()` when passing
JNI string content to ThorVG so the loader receives
the UTF-8 byte length instead of the Kotlin UTF-16
character count.

## 6. [fix: invalidate Compose Lottie canvas on each SW frame](https://github.com/thorvg/thorvg.android/pull/30/changes/cf4ffcb08b8fd91d3d04bf550978513fd35718a4)

`lottieState.isPlaying` defaults to `true`, so a sample should start playing automatically as soon as it opens.

```kt
val lottieState = rememberLottieState(
    isPlaying = true,
    repeatCount = LottieConstants.INFINITE
)
```

However, when `ComposeStatusPanel` was removed, the animation no longer auto-played. This fixes that so the animation plays automatically even without `ComposeStatusPanel`.

### Before
`ComposeStatusPanel` removed → animation does not auto-play in the sample

https://github.com/user-attachments/assets/2301f703-90e8-4625-8511-ffecd94476b8

### After
`ComposeStatusPanel` removed → animation auto-plays in the sample

https://github.com/user-attachments/assets/baa75c42-4a57-407e-931f-722b7322977c

</details>

