### PR TITLE
fix: Lottie frame and Replay issues

### DIFF
--- a/thorvg-compose/src/main/java/org/thorvg/compose/lottie/Lottie.kt
+++ b/thorvg-compose/src/main/java/org/thorvg/compose/lottie/Lottie.kt
@@ -236,9 +236,9 @@ fun Lottie(
         }
 
         val resolvedFirstFrame = firstFrame.coerceAtLeast(0)
-        renderState.lastFrame = (lastFrame ?: composition.frameCount)
+        renderState.lastFrame = (lastFrame ?: composition.lastFrame)
             .coerceAtLeast(resolvedFirstFrame)
-            .coerceAtMost(composition.frameCount)
+            .coerceAtMost(composition.lastFrame)
         renderState.firstFrame = resolvedFirstFrame.coerceAtMost(renderState.lastFrame)
         renderState.setCompositionSize(canvasSize.width, canvasSize.height)
 

--- a/thorvg-core/src/main/java/org/thorvg/core/lottie/LottieComposition.kt
+++ b/thorvg-core/src/main/java/org/thorvg/core/lottie/LottieComposition.kt
@@ -49,6 +49,15 @@ class LottieComposition private constructor(
         get() = nativeLottie.frameCount
 
     /**
+     * Last valid frame index that can be rendered.
+     */
+    val lastFrame: Int
+        get() {
+            val count = frameCount
+            return if (count > 0) count - 1 else 0
+        }
+
+    /**
      * Total animation duration in milliseconds.
      */
     val duration: Long
@@ -147,7 +156,7 @@ class LottieRenderState {
     var lastFrame = 0
         set(value) {
             composition?.let {
-                field = value.coerceAtMost(it.frameCount)
+                field = value.coerceAtLeast(0).coerceAtMost(it.lastFrame)
                 updateFrameInterval()
             }
         }
@@ -179,7 +188,7 @@ class LottieRenderState {
 
     protected fun updateFrameInterval() {
         val currentComposition = composition ?: return
-        val totalFrames = lastFrame - firstFrame
+        val totalFrames = lastFrame - firstFrame + 1
         frameInterval = when {
             totalFrames <= 0 -> 0L
             speed <= 0f -> 0L

--- a/thorvg-view/src/main/java/org/thorvg/view/lottie/LottieDrawable.kt
+++ b/thorvg-view/src/main/java/org/thorvg/view/lottie/LottieDrawable.kt
@@ -444,7 +444,7 @@ class LottieDrawable internal constructor() : ThorVGDrawable(), Animatable {
             val drawable = LottieDrawable()
             drawable.lottieState.composition = LottieComposition.fromRawResource(resources, resId)
             drawable.lottieState.composition?.let { composition ->
-                drawable.setLastFrame(composition.frameCount)
+                drawable.setLastFrame(composition.lastFrame)
             }
             return drawable
         }

--- a/thorvg-view/src/main/java/org/thorvg/view/lottie/LottieDrawable.kt
+++ b/thorvg-view/src/main/java/org/thorvg/view/lottie/LottieDrawable.kt
@@ -242,6 +242,7 @@ class LottieDrawable internal constructor() : ThorVGDrawable(), Animatable {
      * Starts playback from [firstFrame].
      */
     override fun start() {
+        handler.removeCallbacks(nextFrameRunnable)
         isRunning = true
         isEnded = false
         isStarted = false


### PR DESCRIPTION
## 1. [fix: lottie frame bounds](https://github.com/thorvg/thorvg.android/pull/32/changes/e3b79550978a1295a5170ce3feab389d2a18cfe5)

Use the last valid frame index instead of frameCount as the playback end frame, preventing an extra frame from being rendered in View and Compose.


<table>
  <tr>
    <th>before(3 second, 3 frame)</th>
    <th>after(2 second, 2 frame)</th>
    <th>Web lottie view(2 second, 2 frame)</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/e1f524d7-b41c-41eb-ab8a-0f99826c532d"></video></td>
    <td><video src="https://github.com/user-attachments/assets/1db19a8c-8b85-4bea-87c7-a93822b16be9"></video></td>
    <td><video src="https://github.com/user-attachments/assets/b8baae8d-a2ac-4511-801c-cd302024e3c3"></video></td>
  </tr>
</table>


## 2. [fix: prevent duplicate nextFrameRunnable](https://github.com/thorvg/thorvg.android/pull/32/changes/f370f7b9b631ed6f940c6d885b086bce5f1e9339)

This causes an issue when Replay is triggered.


https://github.com/user-attachments/assets/dad5a54e-05fa-4a2c-9540-fd75e4fa0410

